### PR TITLE
Use semver. Hopefully.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,12 @@ const semver = require("semver");
 
 try {
   // packageJson.engines.pnpm
-  const massagedPnpmEngine = core.getInput("packageJson-engines-pnpm").slice(2);
+  const massagedPnpmEngine = core.getInput("packageJson-engines-pnpm");
 
   // packageJson.packageManager
   const massagedPackageManager = core
     .getInput("packageJson-packageManager")
-    .slice(5);
+    .replace(/^(?:\w+@)?(.+)$/, '$1');
 
   if (semver.satisfies(massagedPackageManager, massagedPnpmEngine)) {
     console.log(`PNPM version check passed! Returning ${massagedPnpmEngine}`);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const core = require("@actions/core");
+const semver = require("semver");
 
 try {
   // packageJson.engines.pnpm
@@ -9,7 +10,7 @@ try {
     .getInput("packageJson-packageManager")
     .slice(5);
 
-  if (massagedPnpmEngine === massagedPackageManager) {
+  if (semver.satisfies(massagedPackageManager, massagedPnpmEngine)) {
     console.log(`PNPM version check passed! Returning ${massagedPnpmEngine}`);
     core.setOutput("version", massagedPnpmEngine);
   } else {


### PR DESCRIPTION
Uses [semver](https://docs.npmjs.com/cli/v6/using-npm/semver/#usage) for check for compatibility instead of handwriting it. Not sure if we need to do some extra finaggling for this to actually work though.